### PR TITLE
Cache ethernet adapter name

### DIFF
--- a/widgets/network-info.pl
+++ b/widgets/network-info.pl
@@ -10,15 +10,11 @@ my $macRegex = qr"[a-fA-F0-9:]{17}|[a-fA-F0-9]{12}$";
 
 my ($ethernetService, $ethernetIP, $ethernetMAC, $wifiIP, $wifiMAC) = ("Ethernet", "Disconnected", "", "Disconnected", "");
 
-$_ = `networksetup -listallnetworkservices`;
-
-if(/USB\s+10\/100\/1000\s+LAN/) {
-	$ethernetService = "USB 10/100/1000 LAN";	
-}elsif(/Display\s+Ethernet/) {
-	$ethernetService = "Display Ethernet";	
-}elsif(/Thunderbolt\s+Ethernet/) {
-	$ethernetService = "Thunderbolt Ethernet";	
-}
+# config: Run `networksetup -listallnetworkservices` to find the name of your Ethernet network adapter
+# $ethernetService = "Ethernet";
+# $ethernetService = "Display Ethernet";
+# $ethernetService = "Thunderbolt Ethernet";
+$ethernetService = "USB 10/100/1000 LAN";
 
 $_ = `networksetup -getinfo "$ethernetService"`;
 


### PR DESCRIPTION
# Background
Currently, network-info.pl fetches the name of all of your network adapters and attempts to figure out which one is likely your Ethernet adapter. It does this every time it's run, which is inefficient.

# Change
Store the name of the desired ethernet adapter in a variable. It's up to the user to update this variable with the name of the correct Ethernet adapter. This trades a small amount of additional config for a less resource-intensive script. This will be beneficial for users who want their UIs to refresh very frequently (< 1 second)