### PR TITLE
update battery-info.coffee with the correct name for battery-info.pl

### DIFF
--- a/widgets/battery-info.coffee
+++ b/widgets/battery-info.coffee
@@ -1,4 +1,4 @@
-command: "./battery.pl"
+command: "./battery-info.pl"
 
 refreshFrequency: 10000
 


### PR DESCRIPTION
# Background
When I committed the code for this project initially, I updated the names of battery-info.pl and battery-info.coffee to be consistent with other names in this project. However, I forgot to update the contents of battery-info.coffee to reference the new name for battery-info.pl

# Change
Fix the reference to battery-info.pl in battery-info.coffee