### PR TITLE
increase default font size to 18pt

### DIFF
--- a/widgets/battery-info.coffee
+++ b/widgets/battery-info.coffee
@@ -94,7 +94,7 @@ update: (output, domEl) ->
   $(batteryInfo).html(html)
 
 style: """
-  left: 840px
+  left: 850px
   top: 0px
   width: 200px
 """

--- a/widgets/cpu-info.coffee
+++ b/widgets/cpu-info.coffee
@@ -28,9 +28,9 @@ update: (output, domEl) ->
   else if parseFloat(percent_cpu_capacity) < 1 
     text_color_class = "negligible"
 
-  html += "<tr><td width='100px'><span class=" + text_color_class + ">Total Load</span></td>"
-  html += "<td width='50px'><span class=" + text_color_class + ">&nbsp;- " + data.total_cpu_load + "</span></td>"
-  html += "<td width='50px'><span class=" + text_color_class + ">" + percent_cpu_capacity + "%</span></td></tr>" 
+  html += "<tr><td><span class=" + text_color_class + ">Total Load</span></td>"
+  html += "<td><span class=" + text_color_class + ">&nbsp;- " + data.total_cpu_load + "</span></td>"
+  html += "<td><span class=" + text_color_class + ">" + percent_cpu_capacity + "%</span></td></tr>" 
 
   for process in data.processes
     process_cpu_capacity_use = process.percent_of_total_cpu_capacity
@@ -58,8 +58,4 @@ update: (output, domEl) ->
 style: """
   left 190px
   top 0px
-  width 200px
-
-  border none
-  box-sizing border-box
 """

--- a/widgets/css/style.css
+++ b/widgets/css/style.css
@@ -1,7 +1,7 @@
 * {
 	color: #cccccc;
 	font-family: Okuda;
-	font-size: 20px;
+	font-size: 18pt;
 }
 
 .red, .critical {

--- a/widgets/disk-info.coffee
+++ b/widgets/disk-info.coffee
@@ -34,7 +34,7 @@ update: (output, domEl) ->
   $(diskInfo).html(html)
 
 style: """
-  left: 1060px
+  left: 1070px
   top: 0px
   width: 200px
 """

--- a/widgets/memory-info.coffee
+++ b/widgets/memory-info.coffee
@@ -26,9 +26,9 @@ update: (output, domEl) ->
   else if parseFloat(percent_memory_capacity) < 10 
     text_color_class = "negligible"
 
-  html += "<tr><td width='100px'><span class=" + text_color_class + ">Total Memory Used</span></td>"
-  html += "<td width='75px'><span class=" + text_color_class + ">&nbsp;- " + data.total_memory_used + "</span></td>"
-  html += "<td width='50px'><span class=" + text_color_class + ">" + percent_memory_capacity + "%</td></span></tr>" 
+  html += "<tr><td><span class=" + text_color_class + ">Total Memory Used</span></td>"
+  html += "<td><span class=" + text_color_class + ">&nbsp;- " + data.total_memory_used + "</span></td>"
+  html += "<td><span class=" + text_color_class + ">" + percent_memory_capacity + "%</td></span></tr>" 
 
   for process in data.processes
     process_memory_capacity_use = process.percent_memory_used
@@ -53,7 +53,7 @@ update: (output, domEl) ->
 
 style: """
   border none
-  left 400px
+  left 390px
   top 0px
-  width:225px
+  width 300px
 """

--- a/widgets/network-info.coffee
+++ b/widgets/network-info.coffee
@@ -41,6 +41,6 @@ update: (output, domEl) ->
 
 # CSS Style
 style: """
-  left: 625px
+  left: 640px
   top: 0px
 """

--- a/widgets/static-layout.coffee
+++ b/widgets/static-layout.coffee
@@ -31,12 +31,12 @@ style: """
   font-size 20px
 
   #top-section
-    height 270px
+    height 300px
 
   #system-status
-    width 130px
-    height 200px
-    padding 5px
+    width 124px
+    height 225px
+    padding 8px
     color #000
     background-color #5a92b7
 
@@ -51,13 +51,13 @@ style: """
 
   .title-row
     float left
-    height 25px
+    height 28px
     margin-right 5px
 
   .top-title-filler
     width 178px
     background-color #666666
-    height 35px
+    height 38px
     border-bottom-left-radius 35px
 
   .top-title-filler::before
@@ -74,8 +74,8 @@ style: """
 
   .top-title-end-filler
     background-color #666666
-    height 35px
-    width 529px
+    height 38px
+    width 495px
     border-bottom-right-radius 35px
     border-top-right-radius 35px
 
@@ -91,12 +91,12 @@ style: """
     box-shadow: 0 -25px 0 0 #666666;
 
   .metric-title
-    padding 5px
+    padding 5px 8px
     color #000
     background-color #b99609
 
   #resc-main
-    width 420px
+    width 430px
 
   #comm-array
   	width 200px


### PR DESCRIPTION
# Background
The default font size was hard to read on high-res monitors @ 16px

# Changes
- Set default font size to 18pt
- Update spacing of title bars to accommodate increase in info area sizes
- Update widget widths to accommodate increase in font size
- Remove some in-line table column size definitions

# Compromises
The HTML & CSS for the layout is still rigid, and will need further tweaking if I play around with the font size. If I find that I'll be doing this frequently, it'd be better to make the layout more fluid.