### PR TITLE
re-add hardcoded widths for columns in cpu and memory display

### DIFF
--- a/widgets/cpu-info.coffee
+++ b/widgets/cpu-info.coffee
@@ -28,9 +28,9 @@ update: (output, domEl) ->
   else if parseFloat(percent_cpu_capacity) < 1 
     text_color_class = "negligible"
 
-  html += "<tr><td><span class=" + text_color_class + ">Total Load</span></td>"
-  html += "<td><span class=" + text_color_class + ">&nbsp;- " + data.total_cpu_load + "</span></td>"
-  html += "<td><span class=" + text_color_class + ">" + percent_cpu_capacity + "%</span></td></tr>" 
+  html += "<tr><td width='100px'><span class=" + text_color_class + ">Total Load</span></td>"
+  html += "<td width='50px'><span class=" + text_color_class + ">&nbsp;- " + data.total_cpu_load + "</span></td>"
+  html += "<td width='50px'><span class=" + text_color_class + ">" + percent_cpu_capacity + "%</span></td></tr>" 
 
   for process in data.processes
     process_cpu_capacity_use = process.percent_of_total_cpu_capacity

--- a/widgets/memory-info.coffee
+++ b/widgets/memory-info.coffee
@@ -26,9 +26,9 @@ update: (output, domEl) ->
   else if parseFloat(percent_memory_capacity) < 10 
     text_color_class = "negligible"
 
-  html += "<tr><td><span class=" + text_color_class + ">Total Memory Used</span></td>"
-  html += "<td><span class=" + text_color_class + ">&nbsp;- " + data.total_memory_used + "</span></td>"
-  html += "<td><span class=" + text_color_class + ">" + percent_memory_capacity + "%</td></span></tr>" 
+  html += "<tr><td width='110px'><span class=" + text_color_class + ">Total Memory Used</span></td>"
+  html += "<td width='85px'><span class=" + text_color_class + ">&nbsp;- " + data.total_memory_used + "</span></td>"
+  html += "<td width='50px'><span class=" + text_color_class + ">" + percent_memory_capacity + "%</td></span></tr>" 
 
   for process in data.processes
     process_memory_capacity_use = process.percent_memory_used
@@ -55,5 +55,5 @@ style: """
   border none
   left 390px
   top 0px
-  width 300px
+  width 330px
 """

--- a/widgets/memory-info.coffee
+++ b/widgets/memory-info.coffee
@@ -55,5 +55,5 @@ style: """
   border none
   left 390px
   top 0px
-  width 330px
+  width 300px
 """


### PR DESCRIPTION
# Background
In PR #6, I removed the hard-coded column widths for the CPU and Memory displays. I thought they were unnecessary, and an artifact of some layout testing I did during development. However, without those widths, the data in the three columns for the CPU and Memory displays weren't aligning in an aesthetic and easy-to-read manner.

# Change
Re-add the column widths from prior to PR #6, but adjusted to accommodate the font size increase introduced in PR #6.