### PR TITLE
increase width of cpu widget display

### DIFF
--- a/widgets/battery-info.coffee
+++ b/widgets/battery-info.coffee
@@ -94,7 +94,7 @@ update: (output, domEl) ->
   $(batteryInfo).html(html)
 
 style: """
-  left: 850px
+  left: 895px
   top: 0px
   width: 200px
 """

--- a/widgets/cpu-info.coffee
+++ b/widgets/cpu-info.coffee
@@ -28,7 +28,7 @@ update: (output, domEl) ->
   else if parseFloat(percent_cpu_capacity) < 1 
     text_color_class = "negligible"
 
-  html += "<tr><td width='100px'><span class=" + text_color_class + ">Total Load</span></td>"
+  html += "<tr><td width='120px'><span class=" + text_color_class + ">Total Load</span></td>"
   html += "<td width='50px'><span class=" + text_color_class + ">&nbsp;- " + data.total_cpu_load + "</span></td>"
   html += "<td width='50px'><span class=" + text_color_class + ">" + percent_cpu_capacity + "%</span></td></tr>" 
 

--- a/widgets/disk-info.coffee
+++ b/widgets/disk-info.coffee
@@ -34,7 +34,7 @@ update: (output, domEl) ->
   $(diskInfo).html(html)
 
 style: """
-  left: 1070px
+  left: 1110px
   top: 0px
   width: 200px
 """

--- a/widgets/memory-info.coffee
+++ b/widgets/memory-info.coffee
@@ -53,7 +53,7 @@ update: (output, domEl) ->
 
 style: """
   border none
-  left 390px
+  left 410px
   top 0px
   width 300px
 """

--- a/widgets/network-info.coffee
+++ b/widgets/network-info.coffee
@@ -41,6 +41,6 @@ update: (output, domEl) ->
 
 # CSS Style
 style: """
-  left: 640px
+  left: 675px
   top: 0px
 """

--- a/widgets/static-layout.coffee
+++ b/widgets/static-layout.coffee
@@ -96,7 +96,7 @@ style: """
     background-color #b99609
 
   #resc-main
-    width 430px
+    width 460px
 
   #comm-array
   	width 200px


### PR DESCRIPTION
# Background
In #6 and #7, I increased the default font size and tweaked widget sizes to accommodate the need for increased real-estate. Unfortunately, there were still a few cases where a process name would occasionally wrap to 2 lines in the CPU widget because it used wider characters.

# Changes
- Increase the width of the process column in the CPU widget
- Shift the rest of the widgets to the right to make room for the additional space the CPU widget needs
- Increase the size of the title bar for the CPU widget