### PR TITLE
Add circle ci widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+widgets/config/circle-ci.config

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ My personal library of [Übersicht](http://tracesof.net/uebersicht/) widgets, wh
   - _battery-info.pl_ - Edit `$keyboard_name` and `$mouse_name` with the names of your keyboard and mouse as they appear in the output of `system_profiler SPBluetoothDataType 2>&1`
     - Note: Only certain bluetooth devices report their battery status to OSX. This script has only been tested with Apple's Magic Keyboard and Magic Mouse
   - _disk-info.pl_ - Edit `$disk_name` with the name of your preferred disk as it appears in the output of `df -l`
+  - _config/circle-ci.config.example_ - Update the file with your API key and info for the repos & workflows you want the latest build info from. Remove `.example` from the name of the file.
 
 ## Dependencies
 - [Übersicht](http://tracesof.net/uebersicht/), which renders the UI and continuously runs scripts to fetch updates

--- a/widgets/circle-ci-get-workflow-executions.pl
+++ b/widgets/circle-ci-get-workflow-executions.pl
@@ -1,0 +1,42 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use JSON::XS;
+
+my %config = do './config/circle-ci.config';
+
+my $circleci_api_token = $config{circleci_api_token};
+my $vcs_service = $config{vcs_service};
+my $org_name = $config{org_name};
+my $workflows_to_fetch = $config{workflows_to_fetch};
+
+my $max_workflow_executions_to_show = 10;
+
+my @workflow_results;
+
+foreach (@$workflows_to_fetch) {
+	my $workflow_to_fetch = $_;
+
+	my $repo_name = $workflow_to_fetch->{'repo_name'};
+	my $workflow_name = $workflow_to_fetch->{'workflow_name'};
+	my $branch_name = $workflow_to_fetch->{'branch_name'};
+
+	my $workflow_results_json = `curl -sS -H 'Accept: application/json' 'https://circleci.com/api/v2/insights/$vcs_service/$org_name/$repo_name/workflows/$workflow_name?branch=$branch_name&circle-token=$circleci_api_token&limit=$max_workflow_executions_to_show'`;
+
+	my $workflow_result_hash_ref = JSON::XS->new->utf8->decode($workflow_results_json);
+
+	my $lastest_workflow_result = $workflow_result_hash_ref->{'items'}[0];
+
+	$lastest_workflow_result->{'repo_name'} = $repo_name;
+	$lastest_workflow_result->{'workflow_name'} = $workflow_name;
+	$lastest_workflow_result->{'branch_name'} = $branch_name;
+
+	push @workflow_results, $lastest_workflow_result;
+}
+
+my $json = JSON::XS->new->utf8->pretty->allow_nonref;
+my $workflow_info_JSON = $json->encode(\@workflow_results);
+
+print $workflow_info_JSON;

--- a/widgets/circle-ci-service-builds.coffee
+++ b/widgets/circle-ci-service-builds.coffee
@@ -1,0 +1,92 @@
+colors =
+  standard: '#525252'
+  queued  : '#999999'
+  running : '#525252'
+  success : '#80b95b'
+  failed  : '#ff1e7a'
+  fixed   : '#80b95b'
+
+refreshFrequency: 30000
+
+command: "./circle-ci-get-workflow-executions.pl"
+
+update: (output, domEl) ->
+  data = JSON.parse(output)
+  workflow_executions = data
+
+  table  = $(domEl).find('table')
+
+  # Reset the table
+  table.html('')
+
+  getBuildColorClass = (status, created_at) ->
+    build_color_class = 'elevated'
+
+    old_build_threshhold = new Date()
+    old_build_threshhold.setDate(new Date().getDate() - 4)
+    created_at_date = new Date(created_at)
+
+    if status == 'success'
+      if created_at_date < old_build_threshhold
+        build_color_class = 'elevated'
+      else
+        build_color_class = 'nominal'
+    else if (status == 'failed' || status == 'error')
+      build_color_class = 'critical'
+    else if status == 'cancelled'
+      build_color_class = 'negligible'
+    else if status == 'unauthorized'
+      build_color_status = 'issue'
+
+    build_color_class
+
+  formatStatus = (status) ->
+    status = 'queued' if status == 'not_running'
+    status
+
+  formatDuration = (duration) ->
+    duration_minutes = Math.floor(duration / 60)
+    duration_seconds = duration - (duration_minutes * 60)
+    duration_string = duration_minutes + "m " + duration_seconds + "s "
+    duration_string
+
+  formatCreatedAt = (created_at) ->
+    created_at_date = new Date(created_at)
+    created_at_string = created_at_date.toLocaleDateString() + " @ " + created_at_date.toLocaleTimeString()
+    created_at_string
+
+  renderExecution = (workflow_execution) ->
+    build_color_class = getBuildColorClass(workflow_execution.status, workflow_execution.created_at )
+    """
+    <tr>
+      <td><span class="#{build_color_class}">#{workflow_execution.repo_name}/#{workflow_execution.branch_name}</span></td>
+      <td><span class="#{build_color_class}">#{formatCreatedAt(workflow_execution.created_at)}</span></td>
+      <td><span class="#{build_color_class}">#{formatDuration(workflow_execution.duration)}</span></td>
+      <td><span class="#{build_color_class}">#{formatStatus(workflow_execution.status)}</span></td>
+    </tr>
+    """
+
+  table_header = "<tr>"
+  table_header += "<th width='100'>REPO/BRANCH</th>"
+  table_header += "<th width='155'>INITIATED @</th>"
+  table_header += "<th width='70'>DURATION</th>"
+  table_header += "<th width='70'>STATUS</th>"
+  table_header += "</tr>"
+
+  table.append table_header
+
+  for workflow_execution in workflow_executions
+    table.append renderExecution(workflow_execution)
+
+style: """
+  top: 390px
+  left: 190px
+
+  th
+    text-align left
+"""
+
+render: -> """
+  <link rel='stylesheet' href='./css/style.css'>
+  <table id='buildInfo'></table>
+"""

--- a/widgets/config/circle-ci.config.example
+++ b/widgets/config/circle-ci.config.example
@@ -1,0 +1,20 @@
+circleci_api_token => 'api_key',
+vcs_service => 'github',
+org_name => 'my_org',
+workflows_to_fetch => [
+	{
+		repo_name => 'repo1',
+		workflow_name => 'workflow1',
+		branch_name => 'master',
+	},
+	{
+		repo_name => 'repo1',
+		workflow_name => 'workflow1',
+		branch_name => 'staging',
+	},
+	{
+		repo_name => 'repo2',
+		workflow_name => 'workflow2',
+		branch_name => 'master',
+	},
+],

--- a/widgets/css/style.css
+++ b/widgets/css/style.css
@@ -34,3 +34,7 @@ table, th, tr, td {
     padding: 0;
 }	
 
+th {
+	color: #e3c94e;
+	font-weight: normal;
+}

--- a/widgets/static-layout.coffee
+++ b/widgets/static-layout.coffee
@@ -4,18 +4,27 @@ refreshFrequency: false
 
 render: -> """
 
-    <div id="top-section">
-		<div id='system-status'>SYSTEM STATUS</div>
+  <div id='system-status-section'>
+		<div id='system-status-title' class='bottom-spacer'>SYSTEM STATUS</div>
 		<div class='sidebar-filler'></div>
-    </div>
-	<div id="top-section-metrics-titles">
-		<div class='top-title-filler title-row'> </div>
+  </div>
+	<div class='metrics-titles-section bottom-spacer'>
+		<div class='system-status-title-filler title-row'></div>
 		<div id='resc-main' class='metric-title title-row'>RESC-MAIN</div>
 		<div id='comm-array' class='metric-title title-row'>COMMS ARRAY</div>
 		<div id='reactor' class='metric-title title-row'>REACTOR</div>
 		<div id='storage' class='metric-title title-row'>STORAGE</div>
-		<div class='top-title-end-filler title-row'></div>
+		<div class='system-status-titles-end-filler title-row'></div>
  	</div>
+  <div class='metrics-titles-section'>
+    <div class='ops-metrics-title-filler title-row'></div>
+    <div id='missions' class='metric-title title-row'>MISSIONS</div>
+    <div class='ops-status-titles-end-filler title-row'></div>
+  </div>
+  <div id='ops-status-section'>
+    <div class='sidebar-filler bottom-spacer'></div>
+    <div id='ops-status-title'>OPERATIONS STATUS</div>
+  </div>
 """
 
 style: """
@@ -30,39 +39,42 @@ style: """
   font-family Okuda
   font-size 20px
 
-  #top-section
+  #system-status-section
     height 300px
 
-  #system-status
+  #system-status-title
     width 124px
-    height 225px
+    height 244px
     padding 8px
     color #000
     background-color #5a92b7
 
   .sidebar-filler
     background-color #666666
-    margin-top 7px
-    height 60px
+    height 34px
     width 140px
 
-  #top-section-metrics-titles
-    height 100px
+  .metrics-titles-section
+    height 38px
+
+  .bottom-spacer
+    margin-bottom 6px
 
   .title-row
     float left
     height 28px
     margin-right 5px
 
-  .top-title-filler
+  .system-status-title-filler
     width 178px
     background-color #666666
     height 38px
     border-bottom-left-radius 35px
 
-  .top-title-filler::before
+  .system-status-title-filler::before
     content: "";
-    position: absolute;
+    position: relative;
+    display: block;
 
     background-color: transparent;
     left: 140px
@@ -72,23 +84,12 @@ style: """
     border-bottom-left-radius: 50px;
     box-shadow: 0 35px 0 0 #666666;
 
-  .top-title-end-filler
+  .system-status-titles-end-filler
     background-color #666666
     height 38px
-    width 495px
+    width 465px
     border-bottom-right-radius 35px
     border-top-right-radius 35px
-
-  .bottom-title-filler::before
-    content: "";
-    position: absolute;
-
-    background-color: transparent;
-    bottom: -50px;
-    height: 50px;
-    width: 25px;
-    border-top-left-radius: 25px;
-    box-shadow: 0 -25px 0 0 #666666;
 
   .metric-title
     padding 5px 8px
@@ -106,5 +107,44 @@ style: """
 
   #storage
   	width 200px
+
+  .ops-metrics-title-filler
+    width 178px
+    background-color #666666
+    height 38px
+    border-top-left-radius 35px
+
+  .ops-metrics-title-filler::before
+    content: "";
+    position: relative;
+    display: block;
+
+    background-color: transparent;
+    left: 140px;
+    top: 38px;
+    height: 100px;
+    width: 38px;
+    border-top-left-radius: 50px;
+    box-shadow: 0 -35px 0 0 #666666;
+
+  .ops-status-titles-end-filler
+    background-color #666666
+    height 38px
+    width 1208px
+    border-bottom-right-radius 35px
+    border-top-right-radius 35px
+
+  #ops-status-section
+    height 300px
+
+  #ops-status-title
+    width 124px
+    height 640px
+    padding 8px
+    color #000
+    background-color #5a92b7
+
+  #missions
+    width 380px
 
 """


### PR DESCRIPTION
# Background
I wanted to render the most recent workflow execution for the deployment workflow of specific repos and branches of interest to me.

# Changes
- Add script to query circle-ci for the latest workflow execution for a specified repo, branch, and workflow
- Add example config file. The config file is used by the script to retrieve the user's API key, VCS, org name, and desired repo/branch/workflow combinations
- Add view file so the output of the circleci script renders as a widge
- Update the layout to incorporate the new widget
- Update README with instructions on how to turn the example config into a live config