### PR TITLE
Add battery widget for airpods

### DIFF
--- a/widgets/battery-info.coffee
+++ b/widgets/battery-info.coffee
@@ -27,6 +27,27 @@ render: -> """
       </div>
       <div id='mouse-battery-percent-display' class='battery-percent-display'></div>
     </div>
+    <div class='battery-gauge'>
+      <div class='battery-title'>AUX-C</div>
+      <div class='battery-bar-container'>
+        <div id='airpod-case-battery-bar' class='battery-progress-bar'></div>
+      </div>
+      <div id='airpod-case-battery-percent-display' class='battery-percent-display'></div>
+    </div>
+    <div class='battery-gauge'>
+      <div class='battery-title'>AUX-L</div>
+      <div class='battery-bar-container'>
+        <div id='airpod-left-battery-bar' class='battery-progress-bar'></div>
+      </div>
+      <div id='airpod-left-battery-percent-display' class='battery-percent-display'></div>
+    </div>
+    <div class='battery-gauge'>
+      <div class='battery-title'>AUX-R</div>
+      <div class='battery-bar-container'>
+        <div id='airpod-right-battery-bar' class='battery-progress-bar'></div>
+      </div>
+      <div id='airpod-right-battery-percent-display' class='battery-percent-display'></div>
+    </div>
   <div>
 """
 
@@ -105,10 +126,59 @@ update: (output, domEl) ->
 
   # end mouse status
 
+  # If you don't have airpods connected to your system, delete everything until the 'end airpod status' comment to remove it from your UI
+
+  percent_airpod_left_battery_capacity = data.airpod_left_remaining_percent
+  airpods_connected = data.airpods_connected
+  $("#airpod-left-battery-bar").removeClass('battery-idle', 'battery-charging', 'battery-discharging');
+
+  if airpods_connected == 'Yes'
+    airpod_left_status = percent_airpod_left_battery_capacity + "%"
+    text_color_class = get_text_color_class_for_status(percent_airpod_left_battery_capacity)
+    $("#airpod-left-battery-bar").addClass('battery-discharging');
+  else
+    airpod_left_status = "OFFLINE"
+    text_color_class = "negligible"
+    percent_airpod_left_battery_capacity = 0;
+
+  $("#airpod-left-battery-bar").css('height', percent_airpod_left_battery_capacity + '%')
+  $("#airpod-left-battery-percent-display").html("<span class=" + text_color_class + ">" + airpod_left_status + "</span>")
+
+  percent_airpod_right_battery_capacity = data.airpod_right_remaining_percent
+  $("#airpod-right-battery-bar").removeClass('battery-idle', 'battery-charging', 'battery-discharging');
+
+  if airpods_connected == 'Yes'
+    airpod_right_status = percent_airpod_right_battery_capacity + "%"
+    text_color_class = get_text_color_class_for_status(percent_airpod_right_battery_capacity)
+    $("#airpod-right-battery-bar").addClass('battery-discharging');
+  else
+    airpod_right_status = "OFFLINE"
+    text_color_class = "negligible"
+    percent_airpod_right_battery_capacity = 0
+
+  $("#airpod-right-battery-bar").css('height', percent_airpod_right_battery_capacity + '%')
+  $("#airpod-right-battery-percent-display").html("<span class=" + text_color_class + ">" + airpod_right_status + "</span>")
+
+  percent_airpod_case_battery_capacity = data.airpod_case_remaining_percent
+  $("#airpod-case-battery-bar").removeClass('battery-idle', 'battery-charging', 'battery-discharging');
+
+  if percent_airpod_case_battery_capacity > 0
+    airpod_case_status = percent_airpod_case_battery_capacity + "%"
+    text_color_class = get_text_color_class_for_status(percent_airpod_case_battery_capacity)
+    $("#airpod-case-battery-bar").addClass('battery-idle');
+  else
+    airpod_case_status = "OFFLINE"
+    text_color_class = "negligible"
+
+  $("#airpod-case-battery-bar").css('height', percent_airpod_case_battery_capacity + '%')
+  $("#airpod-case-battery-percent-display").html("<span class=" + text_color_class + ">" + airpod_case_status + "</span>")
+
+  # end airpod status
+
   $(batteryInfo).html(html)
 
 style: """
   left: 675px
   top: 0px
-  width: 210px
+  width: 420px
 """

--- a/widgets/battery-info.pl
+++ b/widgets/battery-info.pl
@@ -9,6 +9,7 @@ use JSON::XS;
 # Note: Only certain bluetooth devices report their battery status to OSX. This script has only been tested with Apple's Magic Keyboard and Magic Mouse
 my $keyboard_name = "Shaun Yelle’s Keyboard";
 my $mouse_name = "Shaun Yelle’s Mouse";
+my $airpods_name = "Shaun Yelle's AirPods Pro";
 
 $_ = `system_profiler SPPowerDataType 2>&1`;
 
@@ -60,6 +61,8 @@ if($connected eq 'Yes') {
 $_ = `system_profiler SPBluetoothDataType 2>&1`;
 
 my ($keyboard_connected, $keyboard_remaining_percent, $mouse_connected, $mouse_remaining_percent) = ('No', 0, 'No', 0);
+my ($airpod_left_remaining_percent, $airpod_right_remaining_percent, $airpod_case_remaining_percent, $airpods_connected) = (0, 0, 0, 'No');
+
 
 my $device_name_regex = '(?:' . $keyboard_name . ':).*\n.*\n.*\n.*\n.*\n.*\n.*\n.*\n.*\n.*(?:Battery Level: )(\d+)';
 
@@ -75,6 +78,32 @@ if(/$device_name_regex/) {
   $mouse_connected = 'Yes';  
 }
 
+$device_name_regex = '(?:' . $airpods_name . ':).*\n.*\n.*\n.*\n.*\n.*\n.*\n.*(?:Connected: )(\w+)';
+
+if(/$device_name_regex/) {
+  $airpods_connected = $1;  
+}
+
+$_ = `defaults read /Library/Preferences/com.apple.Bluetooth | grep BatteryPercent`;
+
+$device_name_regex = 'BatteryPercentLeft = (\d+);';
+
+if(/$device_name_regex/) {
+  $airpod_left_remaining_percent = $1;
+}
+
+$device_name_regex = 'BatteryPercentRight = (\d+);';
+
+if(/$device_name_regex/) {
+  $airpod_right_remaining_percent = $1;
+}
+
+$device_name_regex = 'BatteryPercentCase = (\d+);';
+
+if(/$device_name_regex/) {
+  $airpod_case_remaining_percent = $1;
+}
+
 my $batteryInfo = {
   activity => $activity,
   amps => $amps,
@@ -88,6 +117,10 @@ my $batteryInfo = {
   keyboard_connected => $keyboard_connected,
   mouse_remaining_percent => $mouse_remaining_percent,
   mouse_connected => $mouse_connected,
+  airpods_connected => $airpods_connected,
+  airpod_left_remaining_percent => $airpod_left_remaining_percent,
+  airpod_right_remaining_percent => $airpod_right_remaining_percent,
+  airpod_case_remaining_percent => $airpod_case_remaining_percent,
 };
 
 my $json = JSON::XS->new->ascii->pretty->allow_nonref;

--- a/widgets/disk-info.coffee
+++ b/widgets/disk-info.coffee
@@ -34,7 +34,7 @@ update: (output, domEl) ->
   $(diskInfo).html(html)
 
 style: """
-  left: 900px
+  left: 1110px
   top: 60px
   width: 200px
 """

--- a/widgets/network-info.coffee
+++ b/widgets/network-info.coffee
@@ -41,6 +41,6 @@ update: (output, domEl) ->
 
 # CSS Style
 style: """
-  left: 900px
+  left: 1110px
   top: 0px
 """

--- a/widgets/static-layout.coffee
+++ b/widgets/static-layout.coffee
@@ -86,7 +86,7 @@ style: """
   .system-status-titles-end-filler
     background-color #666666
     height 38px
-    width 675px
+    width 475px
     border-bottom-right-radius 35px
     border-top-right-radius 35px
 
@@ -102,7 +102,7 @@ style: """
   	width 200px
 
   #reactor
-  	width 210px
+  	width 420px
 
   .ops-metrics-title-filler
     width 178px


### PR DESCRIPTION
# Background
Airpods report their battery carge to OSX. I wanted to add this info to the metrics display.

# Changes
- Fetch battery info from the OS via pearl
- Add 3 battery meters for the airpod case and 2 buds
- Move disk and network info to the right to make room for expanded battery section