### PR TITLE
Upgrade for OSX BigSur update

### DIFF
--- a/widgets/battery-info.pl
+++ b/widgets/battery-info.pl
@@ -15,7 +15,7 @@ $_ = `system_profiler SPPowerDataType 2>&1`;
 
 my ($remaining, $capacity, $charging, $cycles, $condition, $amps, $volts, $connected) = (0, 0, 'No', 0, 'Unknown', 0, 0, 'No');
 
-if(/\bCharge\s+Remaining\s+\(mAh\):\s+(\w+)/) {
+if(/\bState\s+of\s+Charge\s+\(%\):\s+(\w+)/) {
   $remaining = $1;	
 }
 
@@ -110,8 +110,8 @@ my $batteryInfo = {
   capacity => $capacity,
   condition => $condition,
   cycles => $cycles,
-  remaining => $remaining,
-  remainingPercent => sprintf("%.2f", $remaining/$capacity * 100),
+  remaining => sprintf("%.2f", $capacity * ($remaining / 100)),
+  remainingPercent => $remaining,
   volts => $volts,
   keyboard_remaining_percent => $keyboard_remaining_percent,
   keyboard_connected => $keyboard_connected,

--- a/widgets/disk-info.pl
+++ b/widgets/disk-info.pl
@@ -6,7 +6,7 @@ use warnings;
 use JSON::XS;
 
 # config: Edit `$disk_name` with the name of your preferred disk as it appears in the output of `df -l`
-my $disk_name = '/dev/disk1s1';
+my $disk_name = '/dev/disk1s1s1';
 
 my ($disk_size, $disk_available, $disk_used, $disk_used_percent) = (0, 0, 0, 0);
 


### PR DESCRIPTION
# Background
OSX changed the way battery info is reported when you run `system_profiler SPPowerDataType 2>&1`. Additionally, after the upgrade, my primary disk had `s1` appended to the end of it's name.

# Changes
battery-info.pl - Previously, OSX reported the milliamp hours (mAh) remaining on battery. Now it reports the percent. So instead of calculating the percent based on the mAh remaining, I calculate the mAh remaining based on the percent reported.

disk-info.pl - Update the config portion of the script to use the updated name of my personal hard disk